### PR TITLE
Timing model - normative language adjustments to use statements of fact

### DIFF
--- a/01-Intro.inc.md
+++ b/01-Intro.inc.md
@@ -11,11 +11,11 @@ While alternative interpretations may be equally valid in terms of standards con
 
 Requirements in this document describe client and service behavior that DASH-IF considers interoperable. If you choose to follow these requirements in a published DASH service, that service is likely to experience successful playback on a wide variety of clients and exhibit graceful degradation when a client does not support all features used by the service. Client-oriented requirements describe the mechanisms for consuming services that conform to this document.
 
-This document assumes that the entire DASH presentation conforms to these guidelines. Interoperable behavior cannot be expected from partially conforming presentations.
-
-There is no strict backward compatibility with previous versions - best practices change over time and what was once considered sensible may be replaced by a superior approach later on. Therefore, clients and services that were conforming to version N of this document are not guaranteed to conform to version N+1.
+This document uses statements of fact (e.g. "is" and "can") when describing normative requirements defined in referenced specifications such as [[!MPEGDASH]] and [[!MPEGCMAF]]. [[!RFC2119]] statements (e.g. "SHALL" and "SHOULD") are used when this document defines a new requirement or further constrains a requirement from a referenced document. See also [[#conformance]].
 
 All DASH presentations are assumed to be conforming to [=IOP=]. A service MAY explicitly signal itself as conforming by including the string `https://dashif.org/guidelines/` in `MPD@profiles`.
+
+There is no strict backward compatibility with previous versions - best practices change over time and what was once considered sensible may be replaced by a superior approach later on. Therefore, clients and services that were conforming to version N of this document are not guaranteed to conform to version N+1.
 
 # Disclaimer # {#legal}
 

--- a/21-Timing.inc.md
+++ b/21-Timing.inc.md
@@ -4,51 +4,49 @@ This document presents an interoperable view of DASH presentation timing and seg
 
 The [=MPD=] defines the <dfn>MPD timeline</dfn> which serves as the baseline for all scheduling decisions made during DASH presentation playback.
 
-The playback of a static MPD SHALL NOT depend on the mapping of the MPD timeline to real time. A client MAY play any part of the presentation at any time.
+The playback of a <dfn>static MPD</dfn> (one having `MPD@type="static"`) does not depend on the mapping of the MPD timeline to real time. A client can play any part of the presentation at any time (e.g. it can start playback at any time and seek freely within the entire presentation).
 
-The MPD timeline of a dynamic MPD SHALL have a fixed mapping to real time, with each point on the timeline corresponding to a point in real time. Clients MAY introduce an additional offset with respect to real time [[#timing-timeshift|to the extent allowed by the time shift signaling in the MPD]].
+The [=MPD timeline=] of a <dfn>dynamic MPD</dfn> (one having `MPD@type="dynamic"`) has a fixed mapping to real time, with each point on the [=MPD timeline=] corresponding to a point in real time. Clients can introduce an additional offset with respect to real time [[#timing-timeshift|to the extent allowed by the time shift signaling in the MPD]]. This enables clients to seek within a time span that is constantly changing in real time.
 
-Note: In addition to mapping the content to real time, [[#timing-mpd-updates|a dynamic MPD can be updated during the presentation]]. Updates may add new [=periods=] and remove or modify existing ones, though some restrictions apply. See [[#timing-mpd-updates]].
+Note: In addition to mapping the [=MPD timeline=] to real time, [[#timing-mpd-updates|a dynamic MPD can be updated during the presentation]]. Updates may add new [=periods=] and remove or modify existing ones, though some restrictions apply. See [[#timing-mpd-updates]].
 
-The zero point in the MPD timeline of a dynamic MPD SHALL be mapped to the point in real time indicated by `MPD@availabilityStartTime`. This value SHALL NOT change between MPD updates.
+The zero point on the [=MPD timeline=] of a [=dynamic MPD=] is mapped to the point in real time indicated by `MPD@availabilityStartTime`. This value SHALL NOT change between MPD updates.
 
-The ultimate purpose of the MPD is to enable the client to obtain media samples for playback. The following data structures are most relevant to locating and scheduling the samples:
+The ultimate purpose of the [=MPD=] is to enable the client to obtain media samples for playback. The following data structures are most relevant to locating and scheduling the samples:
 
-1. The MPD consists of consecutive [=periods=] which map data onto the MPD timeline.
+1. The [=MPD=] consists of consecutive [=periods=] which map data onto the [=MPD timeline=].
 1. Each [=period=] contains of one or more [=representations=], each of which provides media samples inside a sequence of [=media segments=].
-1. [=representations=] within a [=period=] are grouped in [=adaptation sets=], which associate related [=representations=] and decorate them with metadata.
+1. [=Representations=] within a [=period=] are grouped in [=adaptation sets=], which associate related [=representations=] and decorate them with metadata.
 
 <figure>
 	<img src="Images/Timing/BasicMpdElements.png" />
-	<figcaption>The primary elements described by an MPD.</figcaption>
+	<figcaption>The primary elements described by an [=MPD=].</figcaption>
 </figure>
-
-The chapters below explore these relationships in detail.
 
 ### Periods ### {#timing-period}
 
-An MPD SHALL define an ordered list of one or more consecutive <dfn title="period">periods</dfn>. A [=period=] is both a time span on the [=MPD timeline=] and a definition of the data to be presented during this time span. [=period=] timing is relative to the zero point of the [=MPD timeline=].
+An [=MPD=] defines an ordered list of one or more consecutive <dfn title="period">periods</dfn>. A [=period=] is both a time span on the [=MPD timeline=] and a definition of the data to be presented during this time span. [=Period=] timing is relative to the zero point of the [=MPD timeline=].
 
 <figure>
 	<img src="Images/Timing/PeriodsMakeTheMpd.png" />
-	<figcaption>An MPD is a collection of consecutive periods.</figcaption>
+	<figcaption>An [=MPD=] is a collection of consecutive periods.</figcaption>
 </figure>
 
-Common reasons for defining multiple periods are:
+Common reasons for defining multiple [=periods=] are:
 
 * Assembling a presentation from multiple self-contained pieces of content.
 * Inserting ads in the middle of existing content and/or replacing spans of existing content with ads.
 * Adding/removing certain [=representations=] as the nature of the content changes (e.g. a new title starts with a different set of offered languages).
 * Updating period-scoped metadata (e.g. codec configuration or DRM signaling).
 
-Periods are self-contained - a service SHALL NOT require a client to know the contents of another [=period=] in order to correctly present a period. Knowledge of the contents of different periods MAY be used by a client to achieve seamless [=period=] transitions, especially when working with [[#timing-connectivity|period-connected [=representations=]]].
+[=Periods=] are self-contained - a service SHALL NOT require a client to know the contents of another [=period=] in order to correctly present a [=period=]. Knowledge of the contents of different periods MAY be used by a client to achieve seamless [=period=] transitions, especially when working with [[#timing-connectivity|period-connected representations]].
 
 All periods SHALL be consecutive and non-overlapping. A [=period=] MAY have a duration of zero.
 
 Note: A [=period=] with a duration of zero might, for example, be the result of ad-insertion logic deciding not to insert any ad.
 
 <div class="example">
-The below MPD example consists of two 20-second periods. The duration of the first [=period=] is calculated using the start point of the second period. The total duration is 40 seconds.
+The below [=static MPD=] consists of two 20-second [=periods=]. The duration of the first [=period=] is calculated using the start point of the second [=period=]. The total duration of the presentation is 40 seconds.
 
 <xmp highlight="xml">
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static">
@@ -61,16 +59,16 @@ The below MPD example consists of two 20-second periods. The duration of the fir
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional MPD file.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional [=MPD=] file.
 </div>
 
-In a static MPD, the first [=period=] SHALL start at the zero point of the [=MPD timeline=]. In a dynamic MPD, the first [=period=] SHALL start at or after the zero point of the [=MPD timeline=].
+In a [=static MPD=], the first [=period=] SHALL start at the zero point of the [=MPD timeline=]. In a [=dynamic MPD=], the first [=period=] SHALL start at or after the zero point of the [=MPD timeline=].
 
-In a static MPD, the last [=period=] SHALL have a `Period@duration`. In a dynamic MPD, the last [=period=] MAY have a `Period@duration`, in which case it has a fixed duration. If without `Period@duration`, the last [=period=] in a dynamic MPD has an unlimited duration.
+In a [=static MPD=], the last [=period=] SHALL have a `Period@duration`. In a [=dynamic MPD=], the last [=period=] MAY have a `Period@duration`, in which case it has a fixed duration. If without `Period@duration`, the last [=period=] in a [=dynamic MPD=] has an unlimited duration.
 
-Note: In a dynamic MPD, a [=period=] with an unlimited duration may be converted to fixed-duration by an MPD update. Periods in a dynamic MPD may also be shortened or removed entirely under certain conditions. See [[#timing-mpd-updates]].
+Note: In a [=dynamic MPD=], a [=period=] with an unlimited duration may be converted to fixed-duration by an MPD update. Periods in a [=dynamic MPD=] can also be shortened or removed entirely under certain conditions. See [[#timing-mpd-updates]].
 
-`MPD@mediaPresentationDuration` MAY be present. If present, it SHALL accurately match the duration between the zero point on the MPD timeline and the end of the last period. Clients SHALL calculate the total duration of a static MPD by adding up the durations of each [=period=] and SHALL NOT rely on the presence of `MPD@mediaPresentationDuration`.
+`MPD@mediaPresentationDuration` MAY be present. If present, it SHALL accurately match the duration between the zero point on the [=MPD timeline=] and the end of the last period. Clients SHALL calculate the total duration of a [=static MPD=] by adding up the durations of each [=period=] and SHALL NOT rely on the presence of `MPD@mediaPresentationDuration`.
 
 Note: This calculation is necessary because the durations of [[#xlink-feature|XLink periods]] can only be known after the [=XLink=] is resolved. Therefore it is impossible to always determine the total [=MPD=] duration on the service side as only the client is guaranteed to have access to all the required knowledge.
 
@@ -80,40 +78,40 @@ A <dfn>representation</dfn> is a sequence of <dfn>segment references</dfn> and a
 
 Each segment reference addresses a [=media segment=] that corresponds to a specific time span on the [=sample timeline=]. Each [=media segment=] contains samples for a specific time span on the [=sample timeline=].
 
-Note: [=Simple addressing=] allows the actual time span of samples within a [=media segment=] to deviate from the nominal time span described in the [=MPD=]. All timing-related clauses in this document refer to the nominal timing described in the MPD unless otherwise noted.
+Note: [=Simple addressing=] allows the actual time span of samples within a [=media segment=] to deviate from the nominal time span described in the [=MPD=]. All timing-related clauses in this document refer to the nominal timing described in the [=MPD=] unless otherwise noted.
 
 The exact mechanism used to define segment references depends on the [=addressing mode=] used by the representation. All [=representations=] in the same [=adaptation set=] SHALL use the same [=addressing mode=].
 
-In a static [=MPD=], a [=representation=] SHALL contain enough [=segment references=] to cover the entire time span of the [=period=].
+In a [=static MPD=], a [=representation=] SHALL contain enough [=segment references=] to cover the entire time span of the [=period=].
 
 <figure>
 	<img src="Images/Timing/StaticMpdMustBeCovered.png" />
-	<figcaption>In a static [=MPD=], the entire [=period=] must be covered with [=media segments=].</figcaption>
+	<figcaption>In a [=static MPD=], the entire [=period=] must be covered with [=media segments=].</figcaption>
 </figure>
 
-In a dynamic [=MPD=], a representation SHALL contain enough segment references to cover the time span of the [=period=] that intersects with the [=time shift buffer=].
+In a [=dynamic MPD=], a [=representation=] SHALL contain enough [=segment references=] to cover the time span of the [=period=] that intersects with the [=time shift buffer=].
 
 Note: [=Media segments=] only become [=available=] when their end point is within the [=availability window=]. It is a valid situation that a [=media segment=] is required to be referenced but is not yet [=available=].
 
 <figure>
 	<img src="Images/Timing/MandatorySegmentReferencesInDynamicMpd.png" />
-	<figcaption>In a dynamic [=MPD=], the [=time shift buffer=] determines the set of required segment references in each representation. [=Media segments=] filled with gray need not be referenced due to falling outside the [=time shift buffer=], despite falling within the bounds of a [=period=].</figcaption>
+	<figcaption>In a [=dynamic MPD=], the [=time shift buffer=] determines the set of required [=segment references=] in each [=representation=]. [=Media segments=] filled with gray need not be referenced due to falling outside the [=time shift buffer=], despite falling within the bounds of a [=period=].</figcaption>
 </figure>
 
-Advisement: A dynamic [=MPD=] must remain valid for its entire validity duration after publishing. In other words, a dynamic MPD SHALL supply enough segment references to allow the [=time shift buffer=] to extend to `now + MPD@minimumUpdatePeriod`, where `now` is the current time according to [[#clock-sync|the synchronized clock]].
+Advisement: A [=dynamic MPD=] must remain valid for its entire validity duration after publishing. In other words, a [=dynamic MPD=] SHALL supply enough [=segment references=] to allow the [=time shift buffer=] to extend to `now + MPD@minimumUpdatePeriod`, where `now` is the current time according to [[#clock-sync|the synchronized clock]].
 
-An unnecessary segment reference is one that is not defined as required by this chapter.
+An <dfn>unnecessary segment reference</dfn> is one that is not defined as required by this chapter.
 
-In a static [=MPD=], a [=representation=] SHALL NOT contain unnecessary segment references, except when using [=indexed addressing=] in which case such segment references MAY be present.
+In a [=static MPD=], a [=representation=] SHALL NOT contain [=unnecessary segment references=], except when using [=indexed addressing=] in which case such segment references MAY be present.
 
-In a dynamic [=MPD=], a [=representation=] SHALL NOT contain unnecessary segment references except when any of the following applies, in which case an unnecessary segment reference MAY be present:
+In a [=dynamic MPD=], a [=representation=] SHALL NOT contain [=unnecessary segment references=] except when any of the following applies, in which case an [=unnecessary segment reference=] MAY be present:
 
-1. The segment reference is for future content and will eventually become necessary.
-1. The segment reference is defined via [=indexed addressing=].
-1. The segment reference is defined by an `<S>` element that defines multiple references using `S@r`, some of which are necessary.
-1. Removal of the segment reference is not allowed by [[#timing-mpd-updates-remove-content|content removal constraints]].
+1. The [=segment reference=] is for future content and will eventually become necessary.
+1. The [=segment reference=] is defined via [=indexed addressing=].
+1. The [=segment reference=] is defined by an `<S>` element that defines multiple references using `S@r`, some of which are necessary.
+1. Removal of the [=segment reference=] is not allowed by [[#timing-mpd-updates-remove-content|content removal constraints]].
 
-There SHALL NOT be gaps or overlapping [=media segments=] in a representation.
+There SHALL NOT be gaps or overlapping [=media segments=] in a [=representation=].
 
 Clients SHALL NOT present any samples from [=media segments=] that are entirely outside the [=period=], even if such [=media segments=] are referenced.
 
@@ -124,7 +122,9 @@ Clients SHALL NOT present any samples from [=media segments=] that are entirely 
 
 [=Media segment=] start/end points MAY be unaligned with [=period=] start/end points except when using [=simple addressing=], which requires the first [=media segment=] start point to match the [=period=] start point.
 
-Note: Despite constraints on first [=media segment=] alignment, [=simple addressing=] allows the media samples within the first [=media segment=] to be unaligned with the [=period=] start point, allowing for synchronization of different reprensetations.
+Issue: Update the above sentence to match [[!MPEGDASH]] 4th edition.
+
+Note: Despite constraints on first [=media segment=] alignment, [=simple addressing=] allows the media samples within the first [=media segment=] to be unaligned with the [=period=] start point, allowing for synchronization of different [=representations=] even when [=simple addressing=] is used.
 
 If a [=media segment=] overlaps a [=period=] boundary, clients SHOULD NOT present the samples that lie outside the [=period=] and SHOULD present the samples that lie either partially or entirely within the [=period=].
 
@@ -134,31 +134,31 @@ Note: In the end, which samples are presented is entirely up to the client. It m
 
 <figure>
 	<img src="Images/Timing/TimelineAlignment.png" />
-	<figcaption>Sample timelines are mapped onto the [=MPD timeline=] based on parameters defined in the MPD.</figcaption>
+	<figcaption>Sample timelines are mapped onto the [=MPD timeline=] based on parameters defined in the [=MPD=].</figcaption>
 </figure>
 
-The samples within a [=representation=] exist on a linear <dfn>sample timeline</dfn> defined by the encoder that created the samples. One or more sample timelines are mapped onto the [=MPD timeline=] by metadata stored in or referenced by the MPD.
+The samples within a [=representation=] exist on a linear <dfn>sample timeline</dfn> defined by the encoder that created the samples. One or more [=sample timelines=] are mapped onto the [=MPD timeline=] by metadata stored in or referenced by the [=MPD=].
 
-Note: A sample timeline is linear - encoders are expected to use an appropriate [=timescale=] and sufficiently large timestamp fields to avoid any wrap-around. If wrap-around does occur, a new [=period=] must be started in order to establish a new sample timeline.
+Note: A [=sample timeline=] is linear - encoders are expected to use an appropriate [=timescale=] and sufficiently large timestamp fields to avoid any wrap-around. If wrap-around does occur, a new [=period=] must be started in order to establish a new [=sample timeline=].
 
-The sample timeline is formed after applying any [[!ISOBMFF]] edit lists.
+The [=sample timeline=] is formed after applying any [[!ISOBMFF]] edit lists.
 
-A sample timeline SHALL be shared by all [=representations=] in the same [=adaptation set=]. [=Representations=] in different [=adaptation sets=] MAY use different sample timelines.
+The same [=sample timeline=] SHALL be shared by all [=representations=] in the same [=adaptation set=]. [=Representations=] in different [=adaptation sets=] MAY use different [=sample timelines=].
 
-The sample timeline is measured in <dfn>timescale units</dfn> defined as a number of units per second. This value (the <dfn>timescale</dfn>) SHALL be present in the MPD as `SegmentTemplate@timescale` or `SegmentBase@timescale` (depending on the [=addressing mode=]).
+The [=sample timeline=] is measured in <dfn>timescale units</dfn> defined as a number of units per second. This value (the <dfn>timescale</dfn>) SHALL be present in the MPD as `SegmentTemplate@timescale` or `SegmentBase@timescale` (depending on the [=addressing mode=]).
 
 Note: While optional in [[!MPEGDASH]], the presence of the `@timescale` attribute is required by the interoperable timing model because the default value of 1 is unlikely to match any real-world content and is far more likely to indicate an unintentional content authoring error.
 
 <figure>
 	<img src="Images/Timing/PresentationTimeOffset.png" />
-	<figcaption>`@presentationTimeOffset` is the key component in establishing the relationship between the [=MPD timeline=] and a sample timeline.</figcaption>
+	<figcaption>`@presentationTimeOffset` is the key component in establishing the relationship between the [=MPD timeline=] and a [=sample timeline=].</figcaption>
 </figure>
 
-The point on the sample timeline indicated by `@presentationTimeOffset` SHALL be equivalent to the [=period=] start point on the [=MPD timeline=]. The value is provided by `SegmentTemplate@presentationTimeOffset` or `SegmentBase@presentationTimeOffset`, depending on the [=addressing mode=], and has a default value of 0 [=timescale units=].
+The point on the [=sample timeline=] indicated by `@presentationTimeOffset` is equivalent to the [=period=] start point on the [=MPD timeline=]. The value is provided by `SegmentTemplate@presentationTimeOffset` or `SegmentBase@presentationTimeOffset`, depending on the [=addressing mode=], and has a default value of 0 [=timescale units=].
 
-Note: To transform a sample timeline position `SampleTime` to an [=MPD timeline=] position, use the formula `MpdTime = Period@start + (SampleTime - @presentationTimeOffset) / @timescale`.
+Note: To transform a [=sample timeline=] position `SampleTime` to an [=MPD timeline=] position, use the formula `MpdTime = Period@start + (SampleTime - @presentationTimeOffset) / @timescale`.
 
-`@presentationTimeOffset` SHALL NOT change between updates of a dynamic MPD.
+`@presentationTimeOffset` SHALL NOT change between updates of a [=dynamic MPD=].
 
 ### Clock drift is forbidden ### {#no-clock-drift}
 
@@ -188,15 +188,15 @@ Note: Different media segments may be different byte ranges accessed on the same
 
 Advisement: Even when using [=simple addressing=], the [=media segment=] that starts at or overlaps the [=period=] start point SHALL contain a media sample that starts at or overlaps the [=period=] start point and the [=media segment=] that ends at or overlaps the [=period=] end point SHALL contain a media sample that ends at or overlaps the [=period=] end point.
 
-[[#segment-alignment-constraints|Aligned]] [=media segments=] in different [=representations=] SHALL contain samples for the same true time span, even if using [=simple addressing=] with [[#addressing-simple-inaccuracy|inaccurate media segment timing]].
+[[#segment-alignment|Aligned media segments]] in different [=representations=] SHALL contain samples for the same true time span, even if using [=simple addressing=] with [[#addressing-simple-inaccuracy|inaccurate media segment timing]].
 
-#### Media segment duration #### {#segment-duration-constraints}
+#### Media segment duration #### {#segment-duration}
 
 [=Media segments=] referenced by the same [=representation=] SHOULD be equal in duration. Occasional jitter MAY occur (e.g. due to encoder decisions on GOP size).
 
 Note: [[DVB-DASH]] defines some relevant constraints in section 4.5. Consider obeying these constraints to be compatible with [[DVB-DASH]].
 
-#### Segments must be aligned #### {#segment-alignment-constraints}
+#### Segments must be aligned #### {#segment-alignment}
 
 [=Media segments=] are said to be aligned if the start/end points of all [=media segments=] on the [=sample timeline=] are equal in all [=representations=] that belong to the same [=adaptation set=].
 
@@ -210,20 +210,20 @@ In certain circumstances content may be offered such that a [=representation=] i
 
 Initialization segments of period-connected [=representations=] SHALL be functionally equivalent (i.e. the initialization segment from any period-connected [=representation=] can be used to initialize playback of any period-connected [=representation=]).
 
-Note: Connectivity is generally achieved by using the same encoder to encode the content of multiple [=periods=] using the same settings. Keep in mind, however, that decryption is also a part of the client media pipeline - it is not only the codec parameters that are configured by the initialization segment.
+Note: Connectivity is generally achieved by using the same encoder to encode the content of multiple [=periods=] using the same settings. Keep in mind, however, that decryption is also a part of the client media pipeline - it is not only the codec parameters that are configured by the initialization segment; different decryption parameters are likely to break connectivity that would otherwise exist.
 
-Such content SHOULD be signaled in the MPD as period-connected. This is expected to help clients ensure seamless playback across [=period=] transitions. Any subset of the [=representations=] in a [=period=] MAY be period-connected with their counterparts in a future or past [=period=]. [=period=] connectivity MAY be chained across any number of [=periods=].
+Such content SHOULD be signaled in the [=MPD=] as [=period-connected=]. This is expected to help clients ensure seamless playback across [=period=] transitions. Any subset of the [=representations=] in a [=period=] MAY be [=period-connected=] with their counterparts in a future or past [=period=]. [=Period=] connectivity MAY be chained across any number of [=periods=].
 
 <figure>
 	<img src="Images/Timing/PeriodConnectivity.png" />
-	<figcaption>[=Representations=] can be signaled as [=period=] connected, enabling client optimizations. Arrows on diagram indicate direction of connectivity reference (from future to past), with the implied message being "the client can use the same decoder it used where the arrow points to".</figcaption>
+	<figcaption>[=Representations=] can be signaled as [=period-connected=], enabling client optimizations. Arrows on diagram indicate direction of connectivity reference (from future to past), with the implied message being "the client can use the same decoder it used where the arrow points to".</figcaption>
 </figure>
 
-An MPD MAY contain unrelated [=periods=] between [=periods=] that contain period-connected [=representations=].
+An [=MPD=] MAY contain unrelated [=periods=] between [=periods=] that contain [=period-connected=] [=representations=].
 
-The [=sample timelines=] of period-connected [=representations=] MAY be mutually discontinuous (e.g. due to skipping some content, encoder clock wrap-around or editorial decisions).
+The [=sample timelines=] of [=period-connected=] [=representations=] MAY be mutually discontinuous (e.g. due to encoder clock wrap-around or skipping some content as a result of editorial decisions).
 
-The following signaling SHALL be used to identify period-connected [=representations=] across two [=periods=]:
+The following signaling SHALL be used to identify [=period-connected=] [=representations=] across two [=periods=]:
 
 * `Representation@id` is equal.
 * `AdaptationSet@id` is equal.
@@ -231,18 +231,18 @@ The following signaling SHALL be used to identify period-connected [=representat
 	* `@shemeIdUri` set to `urn:mpeg:dash:period-connectivity:2015`.
 	* `@value` set to the `Period@id` of the first period.
 
-Note: Not all [=representations=] in an [=adaptation set=] need to be period-connected. For example, if a new [=period=] is introduced to add a [=representation=] that contains a new video quality level, all other [=representations=] will likely be connected but not the one that was added.
+Note: Not all [=representations=] in an [=adaptation set=] need to be [=period-connected=]. For example, if a new [=period=] is introduced to add a [=representation=] that contains a new video quality level, all other [=representations=] will likely be connected but not the one that was added.
 
 <figure>
 	<img src="Images/Timing/SegmentOverlapOnPeriodConnectivity.png" />
-	<figcaption>The same [=media segment=] will often exist in two [=periods=] at a period-connected transition. On the diagram, this is segment 4.</figcaption>
+	<figcaption>The same [=media segment=] will often exist in two [=periods=] at a [=period-connected=] transition. On the diagram, this is segment 4.</figcaption>
 </figure>
 
-As a [=period=] may start and/or end in the middle of a [=media segment=], the same [=media segment=] MAY simultaneously exist in two period-connected [=representations=], with one part of it scheduled for playback during the first [=period=] and the other part during the second [=period=]. This is likely to be the case when no [=sample timeline=] discontinuity is introduced by the transition.
+As a [=period=] may start and/or end in the middle of a [=media segment=], the same [=media segment=] MAY simultaneously exist in two [=period-connected=] [=representations=], with one part of it scheduled for playback during the first [=period=] and the other part during the second [=period=]. This is likely to be the case when no [=sample timeline=] discontinuity is introduced by the transition.
 
-Clients SHOULD NOT present a [=media segment=] twice when it occurs on both sides of a [=period=] transition in a period-connected [=representation=].
+Clients SHOULD NOT present a [=media segment=] twice when it occurs on both sides of a [=period=] transition in a [=period-connected=] [=representation=].
 
-Clients SHOULD ensure seamless playback of period-connected [=representations=] in consecutive [=periods=].
+Clients SHOULD ensure seamless playback of [=period-connected=] [=representations=] in consecutive [=periods=].
 
 Note: The exact mechanism that ensures seamless playback depends on client capabilities and will be implementation-specific. Any shared [=media segment=] overlapping the [=period=] boundary may need to be detected and deduplicated to avoid presenting it twice.
 
@@ -252,7 +252,7 @@ In addition to [[#timing-connectivity|period connectivity]], [[!MPEGDASH]] defin
 
 Note: The above can only be true if the sample boundary exactly matches the [=period=] boundary.
 
-Period continuity MAY be signaled in the MPD when the above condition is met, in which case [=period=] connectivity SHALL NOT be simultaneously signaled on the same [=representation=]. Continuity implies connectivity.
+Period continuity MAY be signaled in the [=MPD=] when the above condition is met, in which case [=period=] connectivity SHALL NOT be simultaneously signaled on the same [=representation=]. Continuity implies connectivity.
 
 The signaling of [=period=] continuity is the same as for [[#timing-connectivity|period connectivity]], except that the value to use for `@schemeIdUri` is `urn:mpeg:dash:period-continuity:2015`.
 
@@ -260,28 +260,28 @@ Clients MAY take advantage of any platform-specific optimizations for seamless p
 
 ### Dynamic MPDs ### {#timing-dynamic}
 
-This section only applies to <dfn>dynamic MPDs</dfn> (`MPD@type="dynamic"`).
+This section only applies to [=dynamic MPDs=].
 
-Dynamic MPDs have two main factors that differentiate them from static MPDs:
+Two main factors differentiate them from [=static MPDs=]:
 
-1. Dynamic MPDs may change over time, with clients retrieving new snapshots of the MPD when the validity duration of the previous snapshot expires.
-1. Playback of a dynamic MPD is synchronized to a real time clock (with some amount of client-chosen time shift allowed).
+1. [=Dynamic MPDs=] may change over time, with clients retrieving new snapshots of the [=MPD=] when the validity duration of the previous snapshot expires.
+1. Playback of a [=dynamic MPD=] is synchronized to a real time clock (with some amount of client-chosen time shift allowed).
 
 DASH clients MAY support the presentation of [=dynamic MPDs=].
 
-A dynamic MPD SHALL conform to the constraints in this document not only at its moment of initial publishing but through the entire <dfn>MPD validity duration</dfn>, which is a period of `MPD@minimumUpdatePeriod` starting from the moment the MPD is acquired by a client, unless overridden by [[#inband|in-band validity signaling]].
+A dynamic MPD SHALL conform to the constraints in this document not only at its moment of initial publishing but through the entire <dfn>MPD validity duration</dfn>, which is a period of `MPD@minimumUpdatePeriod` starting from the moment the MPD download is started by a client, unless overridden by [[#inband|in-band validity signaling]].
 
-Advisement: The MPD validity duration starts when the MPD is downloaded by a client, not when it is generated/published!
+Advisement: The [=MPD validity duration=] starts when the MPD download is initiated by a client, which may be some time after it is generated/published!
 
 #### Real time clock synchronization #### {#clock-sync}
 
-It is critical for [[#timing-dynamic|dynamic MPDs]] to synchronize the clocks of the service and the client. The time indicated by the clock does not necessarily need to match some universal standard as long as the two are mutually synchronized.
+It is critical to synchronize the clocks of the service and the client when using a [=dynamic MPD=]. The time indicated by the clock does not necessarily need to match some universal standard as long as the two are mutually synchronized.
 
-A dynamic MPD SHALL include at least one `UTCTiming` element that defines a clock synchronization mechanism. If multiple `UTCTiming` elements are listed, their order determines the order of preference.
+A [=dynamic MPD=] SHALL include at least one `UTCTiming` element that defines a clock synchronization mechanism. If multiple `UTCTiming` elements are listed, their order determines the order of preference.
 
-A client presenting a dynamic MPD SHALL synchronize its local clock according to the `UTCTiming` elements in the MPD and SHALL emit a warning or error to application developers when clock synchronization fails, no `UTCTiming` elements are defined or none of the referenced clock synchronization mechanisms are supported by the client.
+Advisement: The use of a "default time source" is not allowed. The mechanism of time synchronization must always be explicitly defined in the [=MPD=] by every service and interoperable clients cannot assume a default time source.
 
-Note: The use of a "default time source" is not allowed. The mechanism of time synchronization must always be explicitly defined in the MPD by every service and interoperable clients cannot assume a default time source.
+A client presenting a [=dynamic MPD=] SHALL synchronize its local clock according to the `UTCTiming` elements in the [=MPD=] and SHALL emit a warning or error to application developers when clock synchronization fails, no `UTCTiming` elements are defined or none of the referenced clock synchronization mechanisms are supported by the client.
 
 The set of time synchronization mechanisms SHALL be restricted to the following schemes defined in [[!MPEGDASH]]:
 
@@ -292,19 +292,19 @@ The set of time synchronization mechanisms SHALL be restricted to the following 
 * urn:mpeg:dash:utc:http-head:2014
 * urn:mpeg:dash:utc:direct:2014
 
-Issue: We could use some detailed examples here, especially as clock sync is such a critical element of live services.
+Issue: We could benefit from some detailed examples here, especially as clock sync is such a critical element of live services.
 
 #### Availability #### {#timing-availability}
 
-A segment is <dfn>available</dfn> if an HTTP request to acquire it can be successfully performed to completion by a client. In a dynamic MPD, new [=media segments=] continuously become available and stop being available with the passage of time.
+A [=media segment=] is <dfn>available</dfn> when an HTTP request to acquire the [=media segment=] can be started and successfully performed to completion by a client. During playback of a [=dynamic MPD=], new [=media segments=] continuously become [=available=] and stop being [=available=] with the passage of time.
 
-An <dfn>availability window</dfn> is a time span on the [=MPD timeline=] that determines which [=media segments=] are available. Each [=representation=] has its own availability window.
+An <dfn>availability window</dfn> is a time span on the [=MPD timeline=] that determines which [=media segments=] can be expected to be [=available=]. Each [=representation=] has its own [=availability window=].
 
-A service SHALL ensure that all [=media segments=] that have their **end point** inside or at the end of the availability window are available.
+A service SHALL make [=available=] all [=media segments=] that have their **end point** inside or at the end of the [=availability window=].
 
-Advisement: It is the responsibility of the service to ensure that [=media segments=] are available to clients when they are described as available by the MPD. To define proper availability timing, one must consider the entire publishing flow through the CDN, not only when the origin server makes data available to the CDN.
+Advisement: It is the responsibility of the service to ensure that [=media segments=] are [=available=] to clients when they are described as [=available=] by the [=MPD=]. Consider that the criterium for availability is a successful download by clients, not successful publishing from a packager.
 
-The availability window is calculated as follows:
+The [=availability window=] is calculated as follows:
 
 <div class="algorithm">
 
@@ -318,69 +318,73 @@ The availability window is calculated as follows:
 
 <figure>
 	<img src="Images/Timing/AvailabilityWindow.png" />
-	<figcaption>The availability window determines which [=media segments=] are available, based on where their end point lies.</figcaption>
+	<figcaption>The [=availability window=] determines which [=media segments=] can be expected to be [=available=], based on where their end point lies.</figcaption>
 </figure>
 
-Clients MAY attempt to acquire any available [=media segment=]. Clients SHALL NOT attempt to acquire [=media segments=] that are not available.
+Clients MAY at any point attempt to acquire any [=media segments=] that the [=MPD=] signals as [=available=]. Clients SHALL NOT attempt to acquire [=media segments=] that the [=MPD=] does not signal as [=available=].
 
-Clients SHOULD NOT assume that [=media segments=] described by the MPD as available are always available at the correct moment in time and SHOULD implement appropriate retry behavior.
+Clients SHOULD NOT assume that [=media segments=] described by the [=MPD=] as [=available=] are [=available=] and SHOULD implement appropriate retry/fallback behavior to account for timing errors by slow-publishing or eagerly-unpublishing services.
 
 #### Time shift buffer #### {#timing-timeshift}
 
-The <dfn>time shift buffer</dfn> is a time span on the [=MPD timeline=] that defines the set of [=media segments=] that a client can present at the current moment in time according to [[#clock-sync|the synchronized clock]] (`now`).
+The <dfn>time shift buffer</dfn> is a time span on the [=MPD timeline=] that defines the set of [=media segments=] that a client is allowed to present at the current moment in time according to [[#clock-sync|the synchronized clock]] (`now`).
 
-The following additional factors further constrain the set of [=media segments=] that can be presented at the current time:
+This is the mechanism by which clients can introduce a <dfn>time shift</dfn> (an offset) between real time and the [=MPD timeline=] when presenting [=dynamic MPDs=]. The [=time shift=] is zero when a client always chooses to play back the [=media segment=] at the end point of the [=time shift buffer=]. By playing back [=media segments=] from further in the past, a [=time shift=] is introduced.
+
+Note: A [=time shift=] of 30 seconds means that the client starts presenting a [=media segment=] at the moment when its position on the [=MPD timeline=] reaches a distance of 30 seconds from the end of the [=time shift buffer=].
+
+The following additional factors further constrain the set of [=media segments=] that can be presented at the current time and can force a client to introduce a [=time shift=]:
 
 1. [[#timing-availability]] - not every [=media segment=] in the time shift buffer is guaranteed to be [=available=].
-1. [[#timing-delay]] - the service may define a delay that forbids the use of a section of the time shift buffer.
+1. [[#timing-delay]] - the service may define a delay that forbids the use of a section of the [=time shift buffer=].
 
-The time shift buffer extends from `now - MPD@timeShiftBufferDepth` to `now`. In the absence of `MPD@timeShiftBufferDepth` the start of the time shift buffer is `MPD@availabilityStartTime`.
+The [=time shift buffer=] extends from `now - MPD@timeShiftBufferDepth` to `now`. In the absence of `MPD@timeShiftBufferDepth` the start of the [=time shift buffer=] is `MPD@availabilityStartTime`.
 
 <figure>
 	<img src="Images/Timing/TimeShiftBuffer.png" />
-	<figcaption>[=Media segments=] overlapping the time shift buffer may potentially be presented by a client, if other constraints do not forbid it.</figcaption>
+	<figcaption>[=Media segments=] overlapping the [=time shift buffer=] may potentially be presented by a client, if other constraints do not forbid it.</figcaption>
 </figure>
 
-Clients MAY present samples from [=media segments=] that overlap (either in full or in part) the time shift buffer, assuming no other constraints forbid it. Clients SHALL NOT present samples from [=media segments=] that are entirely outside the time shift buffer (whether in the past or the future).
+Clients MAY present samples from [=media segments=] that overlap (either in full or in part) the time shift buffer, assuming no other constraints forbid it. Clients SHALL NOT present samples from [=media segments=] that are entirely outside the [=time shift buffer=] (whether in the past or the future).
 
-The start of the time shift buffer MAY be before the start of the first [=period=]. Clients SHALL NOT allow seeking into regions of the time shift buffer that are not covered by [=periods=].
+The start of the [=time shift buffer=] MAY be before the start of the first [=period=]. Clients SHALL NOT use regions of the [=time shift buffer=] that are not covered by [=periods=].
 
-A dynamic MPD SHALL contain a [=period=] that ends at or overlaps the end point of the time shift buffer, except when reaching [[#timing-mpd-updates-theend|the end of live content]] in which case the last [=period=] MAY end before the end of the time shift buffer.
+A [=dynamic MPD=] SHALL contain a [=period=] that ends at or overlaps the end point of the [=time shift buffer=], except when reaching [[#timing-mpd-updates-theend|the end of live content]] in which case the last [=period=] MAY end before the end of the [=time shift buffer=].
 
 #### Presentation delay #### {#timing-delay}
 
 There is a natural conflict between the [=availability window=] and the [=time shift buffer=]. It is legal for a client to present [=media segments=] as soon as they overlap the [=time shift buffer=], yet such [=media segments=] might not yet be [=available=].
 
-Furthermore, the delay between [=media segments=] entering the [=time shift buffer=] and becoming [=available=] might be different for different [=representations=] that use different segment durations. This difference may also change over time if a [=representation=] does not use a constant segment duration.
+Furthermore, the delay between [=media segments=] entering the [=time shift buffer=] and becoming [=available=] might be different for different [=representations=] that use different [=media segment=] durations. This difference may also change over time if a [=representation=] does not use a constant [=media segment=] duration.
 
-Clients SHALL calculate a suitable <dfn>presentation delay</dfn> to ensure that the [=media segments=] it schedules for playback are [=available=] and that there is sufficient time to download them once they become [=available=]. In essence, the presentation delay decreases the [=time shift buffer=], creating an <dfn>effective time shift buffer</dfn> with a reduced duration.
+Clients SHALL calculate a suitable <dfn>presentation delay</dfn> to ensure that the [=media segments=] it schedules for playback are [=available=] and that there is sufficient time to download them once they become [=available=]. In essence, the [=presentation delay=] decreases the [=time shift buffer=], creating an [=effective time shift buffer=] with a reduced duration.
 
-Services MAY define the `MPD@suggestedPresentationDelay` attribute to provide a suggested presentation delay. Clients SHOULD use `MPD@suggestedPresentationDelay` when provided, ignoring the calculated value.
+Services MAY define the `MPD@suggestedPresentationDelay` attribute to provide a suggested [=presentation delay=]. Clients SHOULD use `MPD@suggestedPresentationDelay` when provided, ignoring the calculated value.
 
 Note: As different clients might use different algorithms for calculating the presentation delay, providing `MPD@suggestedPresentationDelay` enables services to roughly synchronize the playback start position of clients.
 
-The effective time shift buffer is the time span from the start of the time shift buffer to `now - PresentationDelay`.
+The <dfn>effective time shift buffer</dfn> is the time span from the start of the [=time shift buffer=] to `now - PresentationDelay`.
 
 <figure>
 	<img src="Images/Timing/WindowInteractions.png" />
-	<figcaption>[=Media segments=] that overlap the effective time shift buffer are the ones that may be presented at time `now`. Two [=representations=] with different segment lengths are shown. Diagram assumes `@availabiltiyTimeOffset=0`.</figcaption>
+	<figcaption>[=Media segments=] that overlap the [=effective time shift buffer=] are the ones that may be presented at time `now`. Two [=representations=] with different segment lengths are shown. Diagram assumes `@availabiltiyTimeOffset=0`.</figcaption>
 </figure>
 
 Clients SHALL constrain seeking to the [=effective time shift buffer=]. Clients SHALL NOT attempt to present [=media segments=] that fall entirely outside the [=effective time shift buffer=].
 
 #### MPD updates #### {#timing-mpd-updates}
 
-Dynamic MPDs MAY change over time. The nature of the change is not restricted unless such a restriction is explicitly defined.
+[=Dynamic MPDs=] MAY change over time. The nature of the change is not restricted unless such a restriction is explicitly defined.
 
-Some common reasons to make changes in dynamic MPDs:
+Some common reasons to make changes in [=dynamic MPDs=]:
 
 * Adding new [=segment references=] to an existing [=period=].
 * Adding new [=periods=].
 * Converting unlimited-duration [=periods=] to fixed-duration [=periods=] by adding `Period@duration`.
 * Removing [=segment references=] and/or [=periods=] that have fallen out of the [=time shift buffer=].
 * Shortening an existing [=period=] when changes in content scheduling take place.
-* Removing `MPD@minimumUpdatePeriod` to signal that MPD will no longer be updated (even though it may remain a dynamic MPD).
-* Converting the MPD to a static MPD to signal that a live service has become available on-demand as a recording.
+* Removing `MPD@minimumUpdatePeriod` to signal that [=MPD=] will no longer be updated.
+* Converting the [=MPD=] to a [=static MPD=] to signal that a live service has become available on-demand as a recording.
 
 The following basic restrictions are defined here for MPD updates:
 
@@ -399,15 +403,15 @@ Advisement: Additional restrictions on MPD updates are defined by other parts of
 
 Clients SHOULD use `@id` to track [=period=], [=adaptation set=] and [=representation=] identity across MPD updates.
 
-The presence or absence of `MPD@minimumUpdatePeriod` SHALL be used by a service to signal whether the MPD might be updated (with presence indicating potential for future updates). The value of this field indicates the [=MPD validity duration=] of the present snapshot of the MPD, starting from the moment it was retrieved.
+The presence or absence of `MPD@minimumUpdatePeriod` SHALL be used by a service to signal whether the MPD might be updated (with presence indicating potential for future updates). The value of this field indicates the [=MPD validity duration=] of the present snapshot of the [=MPD=], starting from the moment its download was initiated.
 
-Clients SHALL process state changes that occur during the [=MPD validity duration=]. For example new [=media segments=] will become [=available=] over time if they are referenced by the MPD and old ones become unavailable, even without an MPD update.
+Clients SHALL process state changes that occur during the [=MPD validity duration=]. For example new [=media segments=] will become [=available=] over time if they are referenced by the [=MPD=] and old ones become unavailable, even without an [=MPD=] update.
 
-Note: A missing `MPD@minimumUpdatePeriod` attribute indicates an infinite validinity [=period=] (the MPD will never be updated). The value 0 indicates that the MPD has no validity after the moment it was retrieved. In such a situation, the client will have to acquire a new MPD whenever it wants to make new [=media segments=] available (no "natural" state changes will occur).
+Note: Absence of the `MPD@minimumUpdatePeriod` attribute indicates an infinite validinity [=period=] (the [=MPD=] will never be updated). The value 0 indicates that the [=MPD=] has no validity after the moment it was retrieved. In such a situation, the client will have to acquire a new [=MPD=] whenever it wants to make new [=media segments=] available (no "natural" state changes will occur).
 
-In practice, clients will also require some time to download and process an MPD update - a service SHOULD NOT assume perfect update timing. Conversely, a client SHOULD NOT assume that it can get all updates in time (it may already be attempting to buffer some [=media segments=] that were removed by an MPD update).
+In practice, clients will also require some time to download and process an [=MPD=] update - a service SHOULD NOT assume perfect update timing. Conversely, a client SHOULD NOT assume that it can get all updates in time (it may already be attempting to buffer some [=media segments=] that were removed by an [=MPD=] update).
 
-In addition to signaling that clients are expected to poll for regular MPD updates, a service MAY publish [[#inband|in-band events to schedule MPD updates]] at moments of its choosing.
+In addition to signaling that clients are expected to poll for regular [=MPD=] updates, a service MAY publish [[#inband|in-band events to update the MPD validity duration]] at moments of its choosing.
 
 ##### Adding content to the MPD ##### {#timing-mpd-updates-add-content}
 
@@ -416,71 +420,69 @@ There are two mechanisms for adding content:
 * Additional [=segment references=] MAY be added to the last [=period=].
 * Additional [=periods=] MAY be added to the end of the MPD.
 
-Multiple content adding mechanisms MAY be combined in a single MPD update.
+Multiple content adding mechanisms MAY be combined in a single [=MPD=] update.
 
 <figure>
 	<img src="Images/Timing/MpdUpdate - AddContent.png" />
-	<figcaption>MPD updates can add both [=segment references=] and [=periods=] (additions highlighted in blue).</figcaption>
+	<figcaption>[=MPD=] updates can add both [=segment references=] and [=periods=] (additions highlighted in blue).</figcaption>
 </figure>
 
 [=Segment references=] SHALL NOT be added to any [=period=] other than the last [=period=]. An MPD update MAY combine adding [=segment references=] to the last [=period=] with adding of new [=periods=].
 
-Note: The duration of the last [=period=] cannot change as a result of adding [=segment references=]. A live service will generally use a [=period=] with an unlimited duration to continuously add new references.
+Note: The duration of the last [=period=] cannot change as a result of adding [=segment references=]. A live service will generally use a [=period=] with an unlimited duration to continuously add new [=segment references=].
 
-When using [=simple addressing=] or [=explicit addressing=], it is possible for a [=period=] to define an infinite sequence of [=segment references=] that extends to the end of the [=period=] (e.g. using `SegmentTemplate@duration` or `r="-1"`). Such self-extending reference sequences SHALL be considered equivalent to explicitly defined reference sequences that extend to the end of the [=period=] and clients MAY obtain new references from such sequences even between MPD updates.
+When using [=simple addressing=] or [=explicit addressing=], it is possible for a [=period=] to define an infinite sequence of [=segment references=] that extends to the end of the [=period=] (e.g. using `SegmentTemplate@duration` or `r="-1"`). Such self-extending reference sequences are equivalent to explicitly defined [=segment reference=] sequences that extend to the end of the [=period=] and clients MAY obtain new [=segment references=] from such sequences even between [=MPD=] updates.
 
-An MPD update that adds content MAY be combined [[#timing-mpd-updates-remove-content|with an MPD update that removes content]].
+An [=MPD=] update that adds content MAY be combined [[#timing-mpd-updates-remove-content|with an MPD update that removes content]].
 
 ##### Removing content from the MPD ##### {#timing-mpd-updates-remove-content}
 
-Removal of content is only allowed if the content to be removed is not yet [=available=] to clients and will not become [=available=] until clients receive the MPD update. See [[#timing-availability]].
+Advisement: Removal of content is only allowed if the content to be removed is not yet [=available=] to clients and guaranteed not to become [=available=] until clients receive the [=MPD=] update. See [[#timing-availability]].
 
-Let `EarliestRemovalPoint` be `availability window end + MPD@minimumUpdatePeriod`.
+To determine the content that may be removed, let `EarliestRemovalPoint` be `availability window end + MPD@minimumUpdatePeriod`.
 
 Note: As each [=representation=] has its own [=availability window=], so does each [=representation=] have its own `EarliestRemovalPoint`.
 
-[=Media segments=] that overlap or end before `EarliestRemovalPoint` might be considered by clients to be [=available=] at the time the MPD update is processed and therefore cannot be removed.
-
 <figure>
 	<img src="Images/Timing/MpdUpdate - RemoveContent.png" />
-	<figcaption>MPD updates can remove both [=segment references=] and [=periods=] (removals highlighted in red).</figcaption>
+	<figcaption>[=MPD=] updates can remove both [=segment references=] and [=periods=] (removals highlighted in red).</figcaption>
 </figure>
 
-An MPD update removing content MAY remove any [=segment references=] to [=media segments=] that start after `EarliestRemovalPoint` at the time the update is published but SHALL NOT remove any other [=segment references=].
+An [=MPD=] update removing content MAY remove any [=segment references=] to [=media segments=] that start after `EarliestRemovalPoint` at the time the update is published.
+
+[=Media segments=] that overlap or end before `EarliestRemovalPoint` might be considered by clients to be [=available=] at the time the [=MPD=] update is processed and therefore SHALL NOT be removed by an [=MPD=] update.
 
 The following mechanisms exist removing content:
 
 * The last [=period=] MAY change from unlimited duration to fixed duration.
 * The duration of the last [=period=] MAY be shortened.
-* One or more [=periods=] MAY be removed entirely from the end of the MPD.
+* One or more [=periods=] MAY be removed entirely from the end of the [=MPD=].
 
-Multiple content removal mechanisms MAY be combined in a single MPD update.
+Multiple content removal mechanisms MAY be combined in a single [=MPD=] update.
 
-The above mechanisms can be used in any extent as long as no constraints defined in this document are violated. In particular, consider the constraints on invalidating [=segment references=] defined in this chapter.
+Note: When using [=indexed addressing=] or [=simple addressing=], removal of [=segment references=] from the end of the [=period=] only requires changing `Period@duration`. When using [=explicit addressing=], pruning some `S` elements may be appropriate to avoid leaving [=unnecessary segment references=].
 
-Note: When using [=indexed addressing=] or [=simple addressing=], removal of [=segment references=] from the end of the [=period=] only requires changing `Period@duration`.
+Clients SHALL NOT fail catastrophically if an [=MPD=] update removes already buffered data but MAY incur unexpected [=time shift=] or a visible transition at the point of removal. It is the responsibility of the service to avoid removing data that may already be in use.
 
-Clients SHALL NOT fail catastrophically if an MPD update removes already buffered data but MAY incur unexpected time shift or a visible transition at the point of removal. It is the responsibility of the service to avoid removing data that may already be in use.
-
-In addition to editorial removal from the end of the MPD, content naturally expires due to the passage of time. Expired content also needs to be removed:
+In addition to editorial removal from the end of the [=MPD=], content naturally expires due to the passage of time. Expired content also needs to be removed:
 
 * Explicitly defined [=segment references=] (`S` elements) SHALL be removed when they have expired (i.e. the [=media segment=] end point has fallen out of the [=time shift buffer=]).
 	* A repeating explicit [=segment reference=] (`S` element with `@r != 0`) SHALL NOT be removed until all repetitions have expired.
 * [=Periods=] with their end points before the time shift buffer SHALL be removed.
 
-An MPD update that removes content MAY be combined [[#timing-mpd-updates-add-content|with an MPD update that adds content]].
+An [=MPD=] update that removes content MAY be combined [[#timing-mpd-updates-add-content|with an MPD update that adds content]].
 
 ##### End of live content ##### {#timing-mpd-updates-theend}
 
 Live services can reach a point where no more content will be produced - existing content will be played back by clients and once they reach the end, playback will cease.
 
-Services SHALL define a fixed duration for the last [=period=], remove the `MPD@minimumUpdatePeriod` attribute and cease performing MPD updates to signal that no more content will be added to the MPD. The `MPD@type` MAY be changed to `static` at this point or later if the service is to be converted to a static MPD for on-demand viewing.
+When this occurs, services SHALL define a fixed duration for the last [=period=], remove the `MPD@minimumUpdatePeriod` attribute and cease performing [=MPD=] updates to signal that no more content will be added to the [=MPD=]. The `MPD@type` MAY be changed to `static` at this point or later if the service is to be converted to a [=static MPD=] for on-demand viewing.
 
 #### MPD refreshes #### {#timing-mpd-refreshes}
 
-To stay informed of the MPD updates, clients need to perform <dfn>MPD refreshes</dfn> at appropriate moments to download the updated [=MPD=] snapshots.
+To stay informed of the [=MPD=] updates, clients need to perform <dfn>MPD refreshes</dfn> at appropriate moments to download the updated [=MPD=] snapshots.
 
-Clients presenting dynamic [=MPDs=] SHALL execute the following [=MPD=] refresh logic:
+Clients presenting [=dynamic MPDs=] SHALL execute the following [=MPD=] refresh logic:
 
 1. When an [=MPD=] snapshot is downloaded, it is valid for the present moment and at least `MPD@minimumUpdatePeriod` after that.
 1. A client can expect to be able to successfully download any [=media segments=] that the [=MPD=] defines as [=available=] at any point during the [=MPD validity duration=].
@@ -490,7 +492,7 @@ Clients presenting dynamic [=MPDs=] SHALL execute the following [=MPD=] refresh 
 
 Note: There is no requirement that clients poll for updates at `MPD@minimumUpdatePeriod` interval. They can do so as often or as rarely as they wish - this attribute simply defines the [=MPD=] validity duration.
 
-Services MAY publish in-band events to explicitly signal MPD validity instead of expecting clients to regularly refresh on their own initiative. This enables finer control by the service but might not be supported by all clients. See [[#inband]].
+Services MAY [[#inband|publish in-band events to explicitly signal MPD validity]] instead of expecting clients to regularly refresh on their own initiative. This enables finer control by the service but might not be supported by all clients. Services SHALL NOT require clients to support in-band events.
 
 ### Timing of stand-alone IMSC1 and WebVTT text files ### {#standalone-text-timing}
 
@@ -512,7 +514,7 @@ IMSC1 subtitles in stored in a stand-alone XML file.
 </AdaptationSet>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional `AdaptationSet` element.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional `AdaptationSet` element.
 </div>
 
 ### Forbidden techniques ### {#timing-nonos}

--- a/22-Addressing.inc.md
+++ b/22-Addressing.inc.md
@@ -22,6 +22,8 @@ A service MAY use [=simple addressing=] which enables the packager logic to be v
 
 Note: Future updates to [[!MPEGDASH]] are expected to eliminate the critical limitations of [=simple addressing=], enabling a wider range of applicable use cases.
 
+Issue: Update to match [[!MPEGDASH]] 4th edition.
+
 [=Indexed addressing=] enables all data associated with a single [=representation=] to be stored in a single [=CMAF track file=] from which byte ranges are served to clients to supply [=media segments=], the [=initialization segment=] and the [=index segment=]. This gives it some unique advantages:
 
 * A single large file is more efficient to transfer and cache than 100 000 or more small files, reducing computational and I/O overhead.
@@ -29,35 +31,35 @@ Note: Future updates to [[!MPEGDASH]] are expected to eliminate the critical lim
 
 ### Indexed addressing ### {#addressing-indexed}
 
-A representation that uses <dfn>indexed addressing</dfn> consists of a [=CMAF track file=] containing an index segment, an initialization segment and a sequence of [=media segments=].
+A representation that uses <dfn>indexed addressing</dfn> consists of a [=CMAF track file=] containing an [=index segment=], an [=initialization segment=] and a sequence of [=media segments=].
 
 Note: This addressing mode is sometimes called "SegmentBase" in other documents.
 
-Clauses in section only apply to [=representations=] that use indexed addressing.
+Clauses in section only apply to [=representations=] that use [=indexed addressing=].
 
-Note: [[MPEGDASH]] makes a distinction between "segment" (HTTP-addressable entity) and "subsegment" (byte range of an HTTP-addressable entity). This document does not make such a distinction and has no concept of subsegments. Usage here matches the definition of [[!MPEGCMAF|CMAF segment]].
+Note: [[!MPEGDASH]] makes a distinction between "segment" (HTTP-addressable entity) and "subsegment" (byte range of an HTTP-addressable entity). This document does not make such a distinction and has no concept of subsegments. Usage of "segment" here matches the definition of CMAF segment [[!MPEGCMAF]].
 
 <figure>
 	<img src="Images/Timing/IndexedAddressing.png" />
-	<figcaption>Indexed addressing is based on an index segment that references all [=media segments=].</figcaption>
+	<figcaption>[=Indexed addressing=] is based on an [=index segment=] that references all [=media segments=].</figcaption>
 </figure>
 
-The MPD defines the byte range in the [=CMAF track file=] that contains the [=index segment=]. The [=index segment=] informs the client of all the [=media segments=] that exist, the time spans they cover on the [=sample timeline=] and their byte ranges.
+The [=MPD=] defines the byte range in the [=CMAF track file=] that contains the [=index segment=]. The [=index segment=] informs the client of all the [=media segments=] that exist, the time spans they cover on the [=sample timeline=] and their byte ranges.
 
-Multiple [=representations=] SHALL NOT be stored in the same [=CMAF track file=].
+Multiple [=representations=] SHALL NOT be stored in the same [=CMAF track file=] (i.e. no multiplexed [=representations=] are to be used).
 
-At least one `Representation/BaseURL` element SHALL be present in the MPD and SHALL contain a reference to the [=CMAF track file=].
+At least one `Representation/BaseURL` element SHALL be present in the [=MPD=], containing a URL pointing to the [=CMAF track file=].
 
-The `SegmentBase@indexRange` attribute SHALL be present in the MPD and SHALL reference the byte range of the segment index in the [=CMAF track file=]. The value SHALL be formatted as a `byte-range-spec` as defined in [[!RFC7233]], referencing a single range of bytes.
+The `SegmentBase@indexRange` attribute SHALL be present in the [=MPD=]. The value of this attribute identifies the byte range of the [=index segment=] in the [=CMAF track file=]. The value is a `byte-range-spec` as defined in [[!RFC7233]], referencing a single range of bytes.
 
 The `SegmentBase@timescale` attribute SHALL be present and its value SHALL match the value of the `timescale` field in the [=index segment=] (in the [[!ISOBMFF]] `sidx` box) and the value of the `timescale` field in the [=initialization segment=] (in the [[!ISOBMFF `tkhd` box)]]).
 
-The `SegmentBase/Initialization@range` attribute SHALL reference the byte range of the initialization segment in the [=CMAF track file=]. The value SHALL be formatted as a `byte-range-spec` as defined in [[!RFC7233]], referencing a single range of bytes. The `Initialization@sourceURL` attribute SHALL NOT be used.
+The `SegmentBase/Initialization@range` attribute SHALL identify the byte range of the initialization segment in the [=CMAF track file=]. The value is a `byte-range-spec` as defined in [[!RFC7233]], referencing a single range of bytes. The `Initialization@sourceURL` attribute SHALL NOT be used.
 
 <div class="example">
-Below is an example of common usage of the indexed addressing mode.
+Below is an example of common usage of [=indexed addressing=].
 
-The example defines a [=timescale=] of 48000 units per second, with the [=period=] starting at position 8100 (or 0.16875 seconds) on the [=sample timeline=]. The client can use the index segment referenced by `indexRange` to determine where the [=media segment=] containing position 8100 (and all other [=media segments=]) can be found. The byte range of the initialization segment is also referenced.
+The example defines a [=timescale=] of 48000 units per second, with the [=period=] starting at position 8100 (or 0.16875 seconds) on the [=sample timeline=]. The client can use the [=index segment=] referenced by `indexRange` to determine where the [=media segment=] containing position 8100 (and all other [=media segments=]) can be found. The byte range of the [=initialization segment=] is also provided.
 
 <xmp highlight="xml">
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011">
@@ -74,12 +76,12 @@ The example defines a [=timescale=] of 48000 units per second, with the [=period
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional MPD file.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional [=MPD=] file.
 </div>
 
 ### Structure of the index segment ### {#addressing-indexed-indexstructure}
 
-The index segment SHALL consist of a single Segment Index Box (`sidx`) as defined by [[!ISOBMFF]]. The field layout is as follows:
+The [=index segment=] SHALL consist of a single Segment Index Box (`sidx`) as defined by [[!ISOBMFF]]. The field layout is as follows:
 
 <xmp>
 aligned(8) class SegmentIndexBox extends FullBox('sidx', version, 0) {
@@ -110,25 +112,22 @@ aligned(8) class SegmentIndexBox extends FullBox('sidx', version, 0) {
 }
 </xmp>
 
-The values of the fields SHALL be as follows:
-
-Note: This matches the definitiuon in [[!ISOBMFF]] but is simply re-worded into an
-[=IOP=] context to better guide implementations in choosing the correct values.
+The values of the fields are determined as follows:
 
 : `reference_ID`
-:: The `track_ID` of the track that contains the data of this [=representation=].
+:: The `track_ID` of the [[!ISOBMFF]] track that contains the data of this [=representation=].
 
 : `timescale`
-:: Same as the `timescale` field of the Media Header Box and same as the `SegmentBase@timescale` attribute in the MPD.
+:: Same as the `timescale` field of the Media Header Box and same as the `SegmentBase@timescale` attribute in the [=MPD=].
 
 : `earliest_presentation_time`
 :: The start timestamp of the first [=media segment=] on the [=sample timeline=], in [=timescale units=].
 
 : `first_offset`
-:: Distance from the anchor point to the first [=media segment=].
+:: Distance from the end of the [=index segment=] to the first [=media segment=], in bytes. For example, 0 indicates that the first [=media segment=] immediately follows the [=index segment=].
 
 : `reference_count`
-:: Total number of [=media segments=] referenced by the index segment.
+:: Total number of [=media segments=] referenced by the [=index segment=].
 
 : `reference_type`
 :: `0`
@@ -161,35 +160,35 @@ For [=representations=] that use [=indexed addressing=], perform the following a
 
 ### Explicit addressing ### {#addressing-explicit}
 
-A representation that uses <dfn>explicit addressing</dfn> consists of a set of [=media segments=] accessed via URLs constructed using a template defined in the MPD, with the exact time span covered by each [=media segment=] described in the MPD.
+A representation that uses <dfn>explicit addressing</dfn> consists of a set of [=media segments=] accessed via URLs constructed using a template defined in the [=MPD=], with the exact time span covered by each [=media segment=] described in the [=MPD=].
 
 Note: This addressing mode is sometimes called "SegmentTemplate with SegmentTimeline" in other documents.
 
-Clauses in section only apply to [=representations=] that use explicit addressing.
+Clauses in section only apply to [=representations=] that use [=explicit addressing=].
 
 <figure>
 	<img src="Images/Timing/ExplicitAddressing.png" />
-	<figcaption>Explicit addressing uses a segment template that is combined with explicitly defined time spans for each [=media segment=] in order to reference [=media segments=], either by start time or by sequence number.</figcaption>
+	<figcaption>[=Explicit addressing=] uses a segment template that is combined with explicitly defined time spans for each [=media segment=] in order to reference [=media segments=], either by start time or by sequence number.</figcaption>
 </figure>
 
-The MPD SHALL contain a `SegmentTemplate/SegmentTimeline` element that contains a set of [=segment references=] which satisfies the requirements defined in this document. The references exist as a sequence of `S` elements, each of which references one or more [=media segments=] with start time `S@t` and duration `S@d` [=timescale units=] on the [=sample timeline=]. The `SegmentTemplate@duration` attribute SHALL NOT be present.
+The [=MPD=] SHALL contain a `SegmentTemplate/SegmentTimeline` element, containing a set of [=segment references=], which satisfies the requirements defined in this document. The [=segment references=] exist as a sequence of `S` elements, each of which references one or more [=media segments=] with start time `S@t` and duration `S@d` [=timescale units=] on the [=sample timeline=]. The `SegmentTemplate@duration` attribute SHALL NOT be present.
 
-To enable concise reference definitions, an `S` element may be a repeating [=segment reference=] that indicates a number of repeated consecutive [=media segments=] with the same duration. The value of `S@r` SHALL indicate the number of additional consecutive [=media segments=] that exist.
+To enable concise [=segment reference=] definitions, an `S` element may represent a repeating [=segment reference=] that indicates a number of repeated consecutive [=media segments=] with the same duration. The value of `S@r` SHALL indicate the number of additional consecutive [=media segments=] that exist.
 
-Note: Only additional references are counted, so `S@r=5` indicates a total of 6 consecutive [=media segments=] with the same duration.
+Note: Only additional [=segment references=] are counted, so `S@r=5` indicates a total of 6 consecutive [=media segments=] with the same duration.
 
-The start time of a [=media segment=] SHALL be calculated from the start time and duration of the previous [=media segment=] if not specified by `S@t`. There SHALL NOT be any gaps or overlap between [=media segments=].
+The start time of a [=media segment=] is calculated from the start time and duration of the previous [=media segment=] if not specified by `S@t`. There SHALL NOT be any gaps or overlap between [=media segments=].
 
-The value of `S@r` SHALL be nonnegative, except for the last `S` element which MAY have a negative value in `S@r`, indicating that the repeated references continue indefinitely up to a [=media segment=] that either ends at or overlaps the [=period=] end point.
+The value of `S@r` is nonnegative, except for the last `S` element which MAY have a negative value in `S@r`, indicating that the repeated [=segment references=] continue indefinitely up to a [=media segment=] that either ends at or overlaps the [=period=] end point.
 
 [[#timing-mpd-updates|Updates to a dynamic MPD]] MAY add more `S` elements, remove expired `S` elements, increment `SegmentTemplate@startNumber`, add the `S@t` attribute to the first `S` element or increase the value of `S@r` on the last `S` element but SHALL NOT otherwise modify existing `S` elements.
 
-The `SegmentTemplate@media` attribute SHALL contain the URL template for referencing [=media segments=], using the `$Time$` or `$Number$` template variable to unique identify [=media segments=]. The `SegmentTemplate@initialization` attribute SHALL contain the URL template for referencing initialization segments.
+The `SegmentTemplate@media` attribute SHALL contain the URL template for referencing [=media segments=], using either the `$Time$` or `$Number$` template variable to unique identify [=media segments=]. The `SegmentTemplate@initialization` attribute SHALL contain the URL template for referencing [=initialization segments=].
 
-If using `$Number$` addressing, the number of the first segment reference SHALL be defined by `SegmentTemplate@startNumber` (default value 1). The `S@n` attribute SHALL NOT be used - segment numbers form a continuous sequence starting with `SegmentTemplate@startNumber`.
+If using `$Number$` addressing, the number of the first segment reference is defined by `SegmentTemplate@startNumber` (default value 1). The `S@n` attribute SHALL NOT be used - segment numbers form a continuous sequence starting with `SegmentTemplate@startNumber`.
 
 <div class="example">
-Below is an example of common usage of the explicit addressing mode.
+Below is an example of common usage of [=explicit addressing=].
 
 The example defines 225 [=media segments=] starting at position 900 on the [=sample timeline=] and lasting for a total of 900.225 seconds. The [=period=] ends at 900 seconds, so the last 0.225 seconds of content is clipped (out of bounds samples may also simply be omitted from the last [=media segment=]). The [=period=] starts at position 900 which matches the start position of the first [=media segment=] found at the relative URL `video/900.m4s`.
 
@@ -210,11 +209,11 @@ The example defines 225 [=media segments=] starting at position 900 on the [=sam
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional MPD file.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional [=MPD=] file.
 </div>
 
 <div class="example">
-Below is an example of the explicit addressing mode used in a scenario where different [=media segments=] have different durations (e.g. due to encoder limitations).
+Below is an example of [=explicit addressing=] used in a scenario where different [=media segments=] have different durations (e.g. due to encoder limitations).
 
 The example defines a sequence of 11 [=media segments=] starting at position 120 on the [=sample timeline=] and lasting for a total of 95520 units at a [=timescale=] of 1000 units per second (which results in 95.52 seconds of data). The [=period=] starts at position 810, which is within the first [=media segment=], found at the relative URL `video/120.m4s`. The fifth [=media segment=] repeats once, resulting in a sixth [=media segment=] with the same duration.
 
@@ -244,7 +243,7 @@ The example defines a sequence of 11 [=media segments=] starting at position 120
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional MPD file.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional [=MPD=] file.
 </div>
 
 #### Moving the period start point (explicit addressing) #### {#addressing-explicit-startpoint}
@@ -257,7 +256,7 @@ For [=representations=] that use [=explicit addressing=], perform the following 
 
 1. Update `SegmentTemplate@presentationTimeOffset` to indicate the desired start point on the [=sample timeline=].
 1. Update `Period@duration` to match the new duration.
-1. Remove any unnecessary segment references.
+1. Remove any [=unnecessary segment references=].
 1. If using the `$Number$` template variable, increment `SegmentTemplate@startNumber` by the number of [=media segments=] removed from the beginning of the [=representation=].
 
 </div>
@@ -266,19 +265,19 @@ Note: See [[#timing-representation]] and [[#timing-mpd-updates-remove-content]] 
 
 ### Simple addressing ### {#addressing-simple}
 
-Issue: Once we have a specific `@earliestPresentationTime` proposal submitted to MPEG we need to update this section to match. See [#245](https://github.com/Dash-Industry-Forum/DASH-IF-IOP/issues/245).
+Issue: Once we have a specific `@earliestPresentationTime` proposal submitted to MPEG we need to update this section to match. See [#245](https://github.com/Dash-Industry-Forum/DASH-IF-IOP/issues/245). This is now done in [[!MPEGDASH]] 4th edition - need to synchronize this text.
 
-A representation that uses <dfn>simple addressing</dfn> consists of a set of [=media segments=] accessed via URLs constructed using a template defined in the MPD, with the nominal time span covered by each [=media segment=] described in the MPD.
+A representation that uses <dfn>simple addressing</dfn> consists of a set of [=media segments=] accessed via URLs constructed using a template defined in the [=MPD=], with the nominal time span covered by each [=media segment=] described in the [=MPD=].
 
-Advisement: Simple addressing defines the nominal time span of each [=media segment=] in the MPD. The true time span covered by samples within the [=media segment=] can be slightly different than the nominal time span. See [[#addressing-simple-inaccuracy]].
+Advisement: [=Simple addressing=] defines the nominal time span of each [=media segment=] in the MPD. The true time span covered by samples within the [=media segment=] can be slightly different than the nominal time span. See [[#addressing-simple-inaccuracy]].
 
 Note: This addressing mode is sometimes called "SegmentTemplate without SegmentTimeline" in other documents.
 
-Clauses in section only apply to [=representations=] that use simple addressing.
+Clauses in section only apply to [=representations=] that use [=simple addressing=].
 
 <figure>
 	<img src="Images/Timing/SimpleAddressing.png" />
-	<figcaption>Simple addressing uses a segment template that is combined with approximate first [=media segment=] timing information and an average [=media segment=] duration in order to reference [=media segments=], either by start time or by sequence number.</figcaption>
+	<figcaption>[=Simple addressing=] uses a segment template that is combined with approximate first [=media segment=] timing information and an average [=media segment=] duration in order to reference [=media segments=], either by start time or by sequence number.</figcaption>
 </figure>
 
 The `SegmentTemplate@duration` attribute SHALL define the nominal duration of a [=media segment=] in [=timescale units=].
@@ -287,10 +286,10 @@ The set of [=segment references=] SHALL consist of the first [=media segment=] s
 
 The `SegmentTemplate@media` attribute SHALL contain the URL template for referencing [=media segments=], using either the `$Time$` or `$Number$` template variable to uniquely identify [=media segments=]. The `SegmentTemplate@initialization` attribute SHALL contain the URL template for referencing initialization segments.
 
-If using `$Number$` addressing, the number of the first segment reference SHALL be defined by `SegmentTemplate@startNumber` (default value 1).
+If using `$Number$` addressing, the number of the first segment reference is defined by `SegmentTemplate@startNumber` (default value 1).
 
 <div class="example">
-Below is an example of common usage of the simple addressing mode.
+Below is an example of common usage of [=simple addressing=].
 
 The example defines a [=sample timeline=] with a [=timescale=] of 1000 units per second, with the [=period=] starting at position 900. The average duration of a [=media segment=] is 4001. [=Media segment=] numbering starts at 800, so the first [=media segment=] is found at the relative URL `video/800.m4s`. The sequence of [=media segments=] continues to the end of the period, which is 900 seconds long, making for a total of 225 defined [=segment references=].
 
@@ -308,25 +307,25 @@ The example defines a [=sample timeline=] with a [=timescale=] of 1000 units per
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - this is not a fully functional MPD file.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - this is not a fully functional [=MPD=] file.
 </div>
 
 #### Inaccuracy in media segment timing when using simple addressing #### {#addressing-simple-inaccuracy}
 
-When using [=simple addressing=], the samples contained in a [=media segment=] MAY cover a different time span on the [=sample timeline=] than what is indicated by the nominal timing in the MPD, as long as no constraints defined in this document are violated by this deviation.
+When using [=simple addressing=], the samples contained in a [=media segment=] MAY cover a different time span on the [=sample timeline=] than what is indicated by the nominal timing in the [=MPD=], as long as no constraints defined in this document are violated by this deviation.
 
 <figure>
 	<img src="Images/Timing/InaccurateAddressing.png" />
-	<figcaption>Simple addressing relaxes the requirement on [=media segment=] contents matching the [=sample timeline=]. Red boxes indicate samples.</figcaption>
+	<figcaption>[=Simple addressing=] relaxes the requirement on [=media segment=] contents matching the [=sample timeline=]. Red boxes indicate samples.</figcaption>
 </figure>
 
-The allowed deviation is defined as the maximum offset between the edges of the nominal time span (as defined by the MPD) and the edges of the true time span (as defined by the contents of the [=media segment=]). The deviation is evaluated separately for each edge.
+The allowed deviation is defined as the maximum offset between the edges of the nominal time span (as defined by the [=MPD=]) and the edges of the true time span (as defined by the contents of the [=media segment=]). The deviation is evaluated separately for each edge.
 
 Advisement: This allowed deviation does not relax any requirements that do not explicitly define an exception. For example, [=periods=] must still be covered with samples for their entire duration, which constrains the flexibility allowed for the first and last [=media segment=] in a [=period=].
 
 The deviation SHALL be no more than 50% of the nominal [=media segment=] duration and MAY be in either direction.
 
-Note: This results in a maximum true duration of 200% (+50% outward extension on both edges) and a minimum segment duration of 1 sample (-50% inward from both edges would result in 0 but empty segments are not allowed).
+Note: This results in a maximum true duration of 200% (+50% outward extension on both edges) and a minimum true duration of 1 sample (-50% inward from both edges would result in 0 duration but empty [=media segments=] are not allowed).
 
 Allowing inaccurate timing is intended to enable reasoning on the [=sample timeline=] using average values for [=media segment=] timing. If the addressing data says that a [=media segment=] contains 4 seconds of data on average, a client can predict with reasonable accuracy which samples are found in which [=media segments=], while at the same time the service is not required to publish per-segment timing data in the MPD. It is expected that the content is packaged with this contraint in mind (i.e. **every** segment cannot be inaccurate in the same direction - a shorter segment now implies a longer segment in the future to make up for it).
 
@@ -336,14 +335,12 @@ Consider a [=media segment=] with a nominal start time of 8 seconds from [=perio
 The following are all valid contents for such a [=media segment=]:
 
 * samples from 8 to 12 seconds (perfect accuracy)
-* samples from 6 to 14 seconds (maximally large segment allowed by drift tolerance, 50% increase from both ends)
-* samples from 9.9 to 10 seconds (near-minimally small segment; while drift tolerance allows 50% decrease from both ends, resulting in zero duration, every segment must still contain at least one sample)
-* samples from 6 to 10 seconds (maximal drift toward zero point at both ends)
-* samples from 10 to 14 seconds (maximal drift away from zero point at both ends)
+* samples from 6 to 14 seconds (maximally large segment allowed, 50% increase from both ends)
+* samples from 9.9 to 10 seconds (near-minimally small segment; while we allow a 50% decrease from both ends, potentially resulting in zero duration, every segment must still contain at least one sample)
+* samples from 6 to 10 seconds (maximal offset toward zero point at both ends)
+* samples from 10 to 14 seconds (maximal offset away from zero point at both ends)
 
-Near [=period=] boundaries, all the constraints of timing and addressing must still be respected. Consider a [=media segment=] with a nominal start time of 0 seconds from [=period=] start and a nominal duration of 4 seconds.
-
-If such a [=media segment=] contained samples from 1 to 5 seconds (drift of 1 second away from zero point at both ends, which is within acceptable limits) it would be non-conforming because of the requirement in [[#timing-mediasegment]] that the first [=media segment=] contain a media sample that starts at or overlaps the [=period=] start point.
+Near [=period=] boundaries, all the constraints of timing and addressing must still be respected! Consider a [=media segment=] with a nominal start time of 0 seconds from [=period=] start and a nominal duration of 4 seconds. If such a [=media segment=] contained samples from 1 to 5 seconds (offset of 1 second away from zero point at both ends, which is within acceptable limits) it would be non-conforming because of the requirement in [[#timing-mediasegment]] that the first [=media segment=] contain a media sample that starts at or overlaps the [=period=] start point. This severely limits the usefulness of [=simple addressing=].
 </div>
 
 #### Moving the period start point (simple addressing) #### {#addressing-simple-startpoint}
@@ -352,14 +349,14 @@ When splitting [=periods=] in two or performing other types of editorial timing 
 
 [=Simple addressing=] is challenging to use in such scenarios. You SHOULD convert [=simple addressing=] [=representations=] to use [=explicit addressing=] before adjusting the [=period=] start point or splitting a [=period=]. See [[#addressing-simple-to-explicit]].
 
-The rest of this chapter provides instructions for situations where you choose <em>not</em> to convert to [=explicit addressing=].
+The rest of this chapter provides instructions for situations where you choose **not** to convert to [=explicit addressing=].
 
 To move the [=period=] start point, for [=representations=] that use [=simple addressing=]:
 
-* Every [=simple addressing=] [=representation=] in the [=period=] must contain a [=media segment=] that starts at the new [=period=] start point.
+* Every [=simple addressing=] [=representation=] in the [=period=] must contain a [=media segment=] that starts exactly at the new [=period=] start point.
 * [=Media segments=] starting at the new [=period=] start point must contain a sample that starts at or overlaps the new [=period=] start point.
 
-Note: If you are splitting a [=period=], also keep in mind [[#timing-mediasegment|the requirements on [=period=] end point sample alignment]] for the [=period=] that remains before the split point.
+Note: If you are splitting a [=period=], also keep in mind [[#timing-mediasegment|the requirements on period end point sample alignment]] for the [=period=] that remains before the split point.
 
 Finding a suitable new start point that conforms to the above requirements can be very difficult. If inaccurate timing is used, it may be altogether impossible. This is a limitation of [=simple addressing=].
 
@@ -377,13 +374,13 @@ Having ensured conformance to the above requirements for the new [=period=] star
 
 It may sometimes be desirable to convert a presentation from [=simple addressing=] to [=explicit addressing=]. This chapter provides an algorithm to do this.
 
-Advisement: [=Simple addressing=] allows for inaccuracy in [=media segment=] timing. No inaccuracy is allowed by [=explicit addressing=]. The mechanism of conversion described here only applies when there is no inaccuracy. If the nominal time spans in original the MPD differ from the true time spans of the [=media segments=], re-package the content from scratch using [=explicit addressing=] instead of converting.
+Advisement: [=Simple addressing=] allows for inaccuracy in [=media segment=] timing. No inaccuracy is allowed by [=explicit addressing=]. The mechanism of conversion described here is only valid when there is no inaccuracy. If the nominal time spans in original the [=MPD=] differ from the true time spans of the [=media segments=], re-package the content from scratch using [=explicit addressing=] instead of converting.
 
 To perform the conversion, execute the following steps:
 
 <div class="algorithm">
 
-1. Calculate the number of [=media segments=] in the representation as `SegmentCount = Ceil(AsSeconds(Period@duration) / ( SegmentTemplate@duration / SegmentTemplate@timescale))`.
+1. Calculate the number of [=media segments=] in the [=representation=] as `SegmentCount = Ceil(AsSeconds(Period@duration) / ( SegmentTemplate@duration / SegmentTemplate@timescale))`.
 1. Update the MPD.
 	1. Add a single `SegmentTemplate/SegmentTimeline` element.
 	1. Add a single `SegmentTimeline/S` element.
@@ -433,5 +430,5 @@ After conversion, we arrive at the following result.
 </MPD>
 </xmp>
 
-Parts of the MPD structure that are not relevant for this chapter have been omitted - the above are not fully functional MPD files.
+Parts of the [=MPD=] structure that are not relevant for this chapter have been omitted - the above are not fully functional [=MPD=] files.
 </div>


### PR DESCRIPTION
If requirement is imported from reference, just use statement of fact language:

> This document uses statements of fact (e.g. "is" and "can") when describing normative requirements defined in referenced specifications such as [[!MPEGDASH]] and [[!MPEGCMAF]]. [[!RFC2119]] statements (e.g. "SHALL" and "SHOULD") are used when this document defines a new requirement or further constrains a requirement from a referenced document. See also [[#conformance]].

Some trivial language/hyperlinking/editorial adjustments also included. Also added some todos for 4th ed work.